### PR TITLE
Adapt load.sh to use gov.uk PaaS postgres as destination via cloudfoundry conduit

### DIFF
--- a/task/Dockerfile
+++ b/task/Dockerfile
@@ -2,6 +2,11 @@ FROM ubuntu:20.04
 
 RUN apt update
 RUN apt install -y curl sqlite python3-pip
+RUN curl https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add -
+RUN echo "deb https://packages.cloudfoundry.org/debian stable main" | tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+RUN apt update
+RUN apt install -y cf8-cli
+RUN cf install-plugin -f conduit
 RUN apt clean
 
 ADD . /src

--- a/task/load.sh
+++ b/task/load.sh
@@ -1,4 +1,18 @@
 #! /usr/bin/env sh
+# Environment Variables:
+## Required for all destinations:
+# * S3_KEY
+# * S3_BUCKET
+## Required for RDS:
+# * DB_NAME
+# * DB_USER_NAME
+# * DB_PASSWORD
+# * DB_WRITE_ENDPOINT
+## Required for CloudFoundry:
+# * CF_USER
+# * CF_PASSWORD
+# * ENVIRONMENT
+# * CF_DATABASE_SERVICE_NAME
 set -e
 
 if [ -f ./.env ]; then
@@ -20,7 +34,15 @@ fi
 echo "exporting $DATABASE"
 sqlite3 $DATABASE ".read sql/export_$DATABASE_NAME.sql"
 
-echo "load data into postgres"
-python3 -m pgload.load --source=$DATABASE_NAME
+if [ -n "$CF_DATABASE_SERVICE_NAME" ]; then
+  echo "load data into gov.uk PaaS postgres"
+  # shellcheck disable=SC2016
+  cf login -a api.london.cloud.service.gov.uk -u $CF_USER -p "$CF_PASSWORD" -s "$ENVIRONMENT"
+  # Cloudfoundry conduit addon does some magic where it executes a process on your host machine that has access a particular cloudfoundry hosted service
+  cf conduit "$CF_DATABASE_SERVICE_NAME" -- bash -c "python3 -m pgload.load_with_vcap_credentials --source=$DATABASE_NAME"
+else
+  echo "load data into RDS postgres"
+  python3 -m pgload.load --source=$DATABASE_NAME
+fi
 
 echo "load done"

--- a/task/pgload/load.py
+++ b/task/pgload/load.py
@@ -1,10 +1,11 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 
 import os
 import logging
 import sys
 import csv
 import psycopg2
+
 import click
 
 from pgload.sql import SQL
@@ -35,17 +36,21 @@ export_tables = {
 
 @click.command()
 @click.option("--source", required=True)
-def do_replace(source):
+def do_replace_cli(source):
 
     host = os.getenv("DB_WRITE_ENDPOINT", "localhost")
     database = os.getenv("DB_NAME", "digital_land")
     user = os.getenv("DB_USER_NAME", "postgres")
     password = os.getenv("DB_PASSWORD", "postgres")
+    port = 5432
+    return do_replace(source, host, database, user, password, port)
 
+
+def do_replace(source, host, database, user, password, port):
     tables_to_export = export_tables[source]
 
     connection = psycopg2.connect(
-        host=host, database=database, user=user, password=password
+        host=host, database=database, user=user, password=password, port=port
     )
     connection.autocommit = False
 
@@ -71,4 +76,4 @@ def do_replace(source):
 
 
 if __name__ == "__main__":
-    do_replace()
+    do_replace_cli()

--- a/task/pgload/load_with_vcap_credentials.py
+++ b/task/pgload/load_with_vcap_credentials.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+import json
+import os
+
+import click
+
+from pgload.load import do_replace
+
+
+@click.command()
+@click.option("--source", required=True)
+def do_replace_cli(source):
+    vcap_services_str = os.getenv("VCAP_SERVICES")
+    if not vcap_services_str:
+        raise Exception("VCAP_SERVICES environment variable missing from environment!")
+    vcap_services = json.loads(vcap_services_str)
+    credentials = vcap_services["postgres"][0]["Credentials"]
+    host = credentials["host"]
+    database = credentials["name"]
+    user = credentials["username"]
+    password = credentials["password"]
+    port = credentials["port"]
+
+    return do_replace(source, host, database, user, password, port)
+
+
+if __name__ == "__main__":
+    do_replace_cli()


### PR DESCRIPTION
Cloudfoundry conduit lets you run a process in your local environment that has an SSH tunnel to a particular cloudfoundry service. It exposes `VCAP_SERVICES` as an environment variable, containing the credentials to authenticate with these services.

I've used to this to run the python `load.py` functionality (wrapped in another module which parses `VCAP_SERVICES` and passes the necessary credentials to `do_replace`) on the native execution environment (tested in the `digital-land-postgres` image built and run on my laptop) to populate a gov.uk PaaS postgres database as it would an RDS postgres instance

We'll need to make a service account to run this on AWS ECS as it requires credentials.

To test this out:
```
docker build -t 955696714113.dkr.ecr.eu-west-2.amazonaws.com/digital-land-postgres task/
docker run -e S3_KEY=digital-land-builder/dataset/digital-land.sqlite3 -e S3_BUCKET=digital-land-production-collection-dataset -e CF_USER=$CF_USER -e CF_PASSWORD="$CF_PASSWORD" -e ENVIRONMENT=staging -e CF_DATABASE_SERVICE_NAME=staging-digital-land-platform-postgres 955696714113.dkr.ecr.eu-west-2.amazonaws.com/digital-land-postgres:latest
docker run -e S3_KEY=entity-builder/dataset/entity.sqlite3 -e S3_BUCKET=digital-land-production-collection-dataset -e CF_USER=$CF_USER -e CF_PASSWORD="$CF_PASSWORD" -e ENVIRONMENT=staging -e CF_DATABASE_SERVICE_NAME=staging-digital-land-postgres 955696714113.dkr.ecr.eu-west-2.amazonaws.com/digital-land-postgres:latest
```