### PR TITLE
Remove version column from SQL export query

### DIFF
--- a/task/sql/export_digital-land.sql
+++ b/task/sql/export_digital-land.sql
@@ -28,7 +28,6 @@ SELECT
     nullif(d.entity_maximum, "") as entity_maximum,
     nullif(d.phase, "") as phase,
     nullif(d.realm, "") as realm,
-    nullif(d.version, "") as version,
     nullif(d.replacement_dataset, "") as replacement_dataset
 FROM dataset d, dataset_theme dt
 WHERE d.dataset = dt.dataset


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We have removed `version` from the specification. We now need to remove it from `digital-land-postgres` as it is currently crashing the action in digital land builder.

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: _Hopefully, this is a minor change that doesn't affect existing tests_
- [ ] I need help with writing tests
